### PR TITLE
Fix log level of error messages

### DIFF
--- a/source/chapter3/5exercise.rst
+++ b/source/chapter3/5exercise.rst
@@ -78,8 +78,7 @@ ch3 中，我们的系统已经能够支持多个任务分时轮流运行，我�
 --------------------------------------------
 
 1. 正确进入 U 态后，程序的特征还应有：使用 S 态特权指令，访问 S 态寄存器后会报错。
-   请同学们可以自行测试这些内容 (运行 `Rust 三个 bad 测例 (ch2b_bad_*.rs) <https://github.com/LearningOS/rCore-Tutorial-Test-2024S/tree/master/src/bin>`_ ，
-   注意在编译时至少需要指定 ``LOG=ERROR`` 才能观察到内核的报错信息) ，
+   请同学们可以自行测试这些内容（运行 `三个 bad 测例 (ch2b_bad_*.rs) <https://github.com/LearningOS/rCore-Tutorial-Test-2024S/tree/master/src/bin>`_ ），
    描述程序出错行为，同时注意注明你使用的 sbi 及其版本。
 
 2. 深入理解 `trap.S <https://github.com/LearningOS/rCore-Tutorial-Code-2024S/blob/ch3/os/src/trap/trap.S>`_


### PR DESCRIPTION
Changed from `error!` to `println!` in 2023S:

- https://github.com/LearningOS/rCore-Tutorial-Code-2022A/blob/2e87f0a35360b096c4f9d50eab70ced0d96347d2/os3/src/trap/mod.rs#L56
- https://github.com/LearningOS/rCore-Tutorial-Code-2023S/blob/8027106c9692fa5c9309fb350b2bd825547ff10b/os/src/trap/mod.rs#L60